### PR TITLE
feat(cpuinfo): NVIDIA GPU 표기 + 부팅 타이밍 보강

### DIFF
--- a/cpuinfo/recipes/universal.json
+++ b/cpuinfo/recipes/universal.json
@@ -3,13 +3,13 @@
     {
       "name": "cpuinfo.sh",
       "url": "https://raw.githubusercontent.com/PeterSuh-Q3/tcrp-addons/master/cpuinfo/src/cpuinfo.sh",
-      "sha256": "1b7e30c8a3c5a7d07cd41ac1f91604db663d840a4dea007e2d9145a101a1cc44",
+      "sha256": "68b729ee7a84e6d294144ee0c5a8bfca8aad7d47322b0a8490a088bdc03199d8",
       "packed": false
     },
     {
       "name": "install.sh",
       "url": "https://raw.githubusercontent.com/PeterSuh-Q3/tcrp-addons/master/cpuinfo/src/install.sh",
-      "sha256": "5d30f23959bd7fbfedbea3cd4c9c6efcb417d17618e1cfaeb8af55d21e4e6b37",
+      "sha256": "9619c8a5d588cc4891a9b5475fb23f26f40d96ba18580cf4e12b97ed4d621ba6",
       "packed": false
     },
     {

--- a/cpuinfo/src/cpuinfo.sh
+++ b/cpuinfo/src/cpuinfo.sh
@@ -131,33 +131,67 @@ else
   # leaves stale gpu_info for the proxy to inject.
   rm -f "${GPU_INFO_FILE}"
 
-  CARDN=$(ls -d /sys/class/drm/card* 2>/dev/null | head -1)
-  if [ -d "${CARDN}" ]; then
+  # Accumulate one JSON object per GPU into GPU_ELEMS (comma-joined). FIRST_*
+  # captures the first GPU for the legacy DSM <= 7.3 single-object t.gpu path.
+  # status="compatible" makes formatGpuDisplayName() show the bare name (any
+  # other/absent status falls through to a "(unknown)" suffix). built_in_gpu_slot_num
+  # / name / clock / memory map to formatGpuInfo()'s destructured fields.
+  GPU_ELEMS=""
+  FIRST_NAME=""; FIRST_CLOCK=""; FIRST_MEMORY=""
+  _json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+  _append_gpu() { [ -z "${GPU_ELEMS}" ] && GPU_ELEMS="$1" || GPU_ELEMS="${GPU_ELEMS},$1"; }
+
+  # 1. DRM cards (Intel i915 / AMD amdgpu). NVIDIA is skipped here and handled
+  #    via nvidia-smi below, since its proprietary driver exposes no
+  #    /sys/class/drm/card* node unless nvidia-drm modeset=1.
+  for CARDN in /sys/class/drm/card[0-9]*; do
+    [ -d "${CARDN}" ] || continue
+    case "${CARDN##*/}" in *-*) continue ;; esac          # skip connector nodes (card0-DP-1)
+    DRV="$(awk -F= '/^DRIVER=/{print $2}' "${CARDN}/device/uevent" 2>/dev/null)"
+    case "${DRV}" in nvidia|nvidia-drm) continue ;; esac
     PCIDN="$(awk -F= '/PCI_SLOT_NAME/ {print $2}' "${CARDN}/device/uevent" 2>/dev/null)"
-    lspci -nnQ
-    # Strip the trailing " (rev NN)" revision suffix that lspci appends; it is
-    # noise in the Info Center GPU name.
-    LNAME="$(lspci -s ${PCIDN:-"99:99.9"} 2>/dev/null | sed "s/.*: //" | sed "s/ *(rev [0-9a-fA-F]*)//")"
-    # LABLE="$(cat "/sys/class/drm/card0/device/label" 2>/dev/null)"
-    CLOCK="0 MHz"
-    [ -f "${CARDN}/gt_max_freq_mhz" ] && CLOCK="$(cat "${CARDN}/gt_max_freq_mhz" 2>/dev/null) MHz"
-    [ -f "${CARDN}/device/pp_dpm_sclk" ] && CLOCK="$(cat "${CARDN}/device/pp_dpm_sclk" 2>/dev/null | grep '\*' | awk '{print $2}') MHz"
-    MEMORY="$(awk '{s=(strtonum($2)-strtonum($1)+1)/1048576} (and(strtonum($3),0x200))&&(and(strtonum($3),0x2000))&&(and(strtonum($3),0x40000))&&s>0{print int(s) " MiB"; exit}' "${CARDN}/device/resource" 2>/dev/null)"
-    if [ -n "${LNAME}" ] && [ -n "${CLOCK}" ] && [ -n "${MEMORY}" ]; then
-      echo "GPU Info set to: \"${LNAME}\" \"${CLOCK}\" \"${MEMORY}\""
-      # DSM <= 7.3 path: inject the t.gpu object client-side (gated by the
-      # support_nvidia_gpu||true patch below).
-      sed -i 's|t=this.getActiveApi(t);let|t=this.getActiveApi(t);if(!t.gpu){t.gpu={};t.gpu.clock="'"${CLOCK}"'";t.gpu.memory="'"${MEMORY}"'";t.gpu.name="'"${LNAME}"'";}let|g' "${FILE_JS}"
-      # DSM 7.4 path: hand the gpu_info[] array to the proxy (see GPU_INFO_FILE).
-      # built_in_gpu_slot_num marks it as an integrated GPU; name/clock/memory
-      # map to formatGpuInfo()'s destructured fields. status="compatible" makes
-      # formatGpuDisplayName() show the bare name (any other/absent status falls
-      # through to a "(unknown)" suffix). JSON-escape the name only (clock/memory
-      # are simple "<n> MHz"/"<n> MiB" strings).
-      GPU_JSON_NAME=$(printf '%s' "${LNAME}" | sed 's/\\/\\\\/g; s/"/\\"/g')
-      printf '[{"name":"%s","status":"compatible","clock":"%s","memory":"%s","built_in_gpu_slot_num":0}]\n' \
-        "${GPU_JSON_NAME}" "${CLOCK}" "${MEMORY}" >"${GPU_INFO_FILE}"
-    fi
+    # Strip the trailing " (rev NN)" revision suffix that lspci appends.
+    GNAME="$(lspci -s ${PCIDN:-"99:99.9"} 2>/dev/null | sed "s/.*: //" | sed "s/ *(rev [0-9a-fA-F]*)//")"
+    GCLOCK="0 MHz"
+    [ -f "${CARDN}/gt_max_freq_mhz" ] && GCLOCK="$(cat "${CARDN}/gt_max_freq_mhz" 2>/dev/null) MHz"
+    [ -f "${CARDN}/device/pp_dpm_sclk" ] && GCLOCK="$(cat "${CARDN}/device/pp_dpm_sclk" 2>/dev/null | grep '\*' | awk '{print $2}') MHz"
+    GMEM="$(awk '{s=(strtonum($2)-strtonum($1)+1)/1048576} (and(strtonum($3),0x200))&&(and(strtonum($3),0x2000))&&(and(strtonum($3),0x40000))&&s>0{print int(s) " MiB"; exit}' "${CARDN}/device/resource" 2>/dev/null)"
+    [ -n "${GNAME}" ] && [ -n "${GCLOCK}" ] && [ -n "${GMEM}" ] || continue
+    [ -z "${FIRST_NAME}" ] && { FIRST_NAME="${GNAME}"; FIRST_CLOCK="${GCLOCK}"; FIRST_MEMORY="${GMEM}"; }
+    echo "GPU Info (drm) set to: \"${GNAME}\" \"${GCLOCK}\" \"${GMEM}\""
+    _append_gpu "$(printf '{"name":"%s","status":"compatible","clock":"%s","memory":"%s","built_in_gpu_slot_num":0}' \
+      "$(_json_escape "${GNAME}")" "${GCLOCK}" "${GMEM}")"
+  done
+
+  # 2. NVIDIA via nvidia-smi (proprietary driver). One row per GPU:
+  #    name, max graphics clock (MHz), total memory (MiB), temperature (C).
+  if command -v nvidia-smi >/dev/null 2>&1 && ls /dev/nvidia[0-9]* >/dev/null 2>&1; then
+    while IFS=, read -r NVN NVC NVM NVT; do
+      NVN="$(printf '%s' "${NVN}" | sed 's/^ *//; s/ *$//')"
+      NVC="$(printf '%s' "${NVC}" | tr -dc '0-9')"
+      NVM="$(printf '%s' "${NVM}" | tr -dc '0-9')"
+      NVT="$(printf '%s' "${NVT}" | tr -dc '0-9')"
+      [ -n "${NVN}" ] || continue
+      NVNAME="NVIDIA ${NVN}"; NVCLOCK="${NVC:-0} MHz"; NVMEM="${NVM:-0} MiB"
+      [ -z "${FIRST_NAME}" ] && { FIRST_NAME="${NVNAME}"; FIRST_CLOCK="${NVCLOCK}"; FIRST_MEMORY="${NVMEM}"; }
+      echo "GPU Info (nvidia) set to: \"${NVNAME}\" \"${NVCLOCK}\" \"${NVMEM}\" ${NVT:-?}C"
+      # temperature_c + tempwarn (both must be defined for the temp row to render).
+      if [ -n "${NVT}" ]; then
+        _append_gpu "$(printf '{"name":"%s","status":"compatible","clock":"%s","memory":"%s","temperature_c":%s,"tempwarn":false,"built_in_gpu_slot_num":0}' \
+          "$(_json_escape "${NVNAME}")" "${NVCLOCK}" "${NVMEM}" "${NVT}")"
+      else
+        _append_gpu "$(printf '{"name":"%s","status":"compatible","clock":"%s","memory":"%s","built_in_gpu_slot_num":0}' \
+          "$(_json_escape "${NVNAME}")" "${NVCLOCK}" "${NVMEM}")"
+      fi
+    done < <(nvidia-smi --query-gpu=name,clocks.max.graphics,memory.total,temperature.gpu --format=csv,noheader,nounits 2>/dev/null)
+  fi
+
+  if [ -n "${GPU_ELEMS}" ]; then
+    # DSM <= 7.3 path: inject the first GPU as the t.gpu object client-side
+    # (gated by the support_nvidia_gpu||true patch below).
+    sed -i 's|t=this.getActiveApi(t);let|t=this.getActiveApi(t);if(!t.gpu){t.gpu={};t.gpu.clock="'"${FIRST_CLOCK}"'";t.gpu.memory="'"${FIRST_MEMORY}"'";t.gpu.name="'"${FIRST_NAME}"'";}let|g' "${FILE_JS}"
+    # DSM 7.4 path: hand the gpu_info[] array to the proxy (see GPU_INFO_FILE).
+    printf '[%s]\n' "${GPU_ELEMS}" >"${GPU_INFO_FILE}"
   fi
 
   sed -i "s/_D(\"support_nvidia_gpu\")},/_D(\"support_nvidia_gpu\")||true},/g" "${FILE_JS}"

--- a/cpuinfo/src/install.sh
+++ b/cpuinfo/src/install.sh
@@ -26,6 +26,41 @@ if [ "${1}" = "late" ]; then
   mkdir -p /tmpRoot/usr/lib/systemd/system/multi-user.target.wants
   ln -sf /usr/lib/systemd/system/cpuinfo.service /tmpRoot/usr/lib/systemd/system/multi-user.target.wants/cpuinfo.service
 
+  # GPU readiness re-trigger: the NVIDIA proprietary driver is loaded late (by
+  # its DSM package), well after cpuinfo.service's fixed boot delay, so the
+  # first run misses the nvidia GPU. Watch /dev/nvidia0 and re-run cpuinfo.sh
+  # once it appears. Intel/AMD are loaded early and already covered by the boot
+  # run; on GPU-less or non-nvidia hosts this path simply never fires (inert).
+  #
+  # The path triggers a SEPARATE oneshot (not cpuinfo.service, which is already
+  # active from boot). RemainAfterExit=yes keeps it active after running so the
+  # PathExists condition does not retrigger it in a loop.
+  GDEST="/tmpRoot/usr/lib/systemd/system/cpuinfo-gpu.service"
+  {
+    echo "[Unit]"
+    echo "Description=MSHELL addon cpuinfo GPU refresh (nvidia readiness)"
+    echo
+    echo "[Service]"
+    echo "Type=oneshot"
+    echo "RemainAfterExit=yes"
+    echo "ExecStart=/usr/sbin/cpuinfo.sh"
+  } >"${GDEST}"
+
+  PDEST="/tmpRoot/usr/lib/systemd/system/cpuinfo-gpu.path"
+  {
+    echo "[Unit]"
+    echo "Description=MSHELL addon cpuinfo GPU watch (/dev/nvidia0)"
+    echo
+    echo "[Path]"
+    echo "PathExists=/dev/nvidia0"
+    echo "Unit=cpuinfo-gpu.service"
+    echo
+    echo "[Install]"
+    echo "WantedBy=multi-user.target"
+  } >"${PDEST}"
+
+  ln -sf /usr/lib/systemd/system/cpuinfo-gpu.path /tmpRoot/usr/lib/systemd/system/multi-user.target.wants/cpuinfo-gpu.path
+
   # mshellscgiproxy (built by .github/workflows/build-mshellscgiproxy.yml)
   if [ -f mshellscgiproxy.tgz ]; then
     tar -zxvf mshellscgiproxy.tgz -C /tmpRoot/usr/sbin


### PR DESCRIPTION
## 배경
DSM 7.4 GPU 섹션 대응(PR #9 머지됨)에 이어, NVIDIA GPU 표기와 부팅 시 드라이버 늦은 로드 대응 추가.

## 변경
- **cpuinfo.sh**: NVIDIA는 `/sys/class/drm/card*`(modeset) 없이도 동작하도록 **nvidia-smi 기반 분기** 추가. name/clock/memory/`temperature_c` 수집, 다중 GPU 누적, DRM 루프에서 `driver=nvidia` 카드는 중복 스킵. (Intel i915/AMD amdgpu 경로 유지)
- **install.sh**: `cpuinfo-gpu.path`(PathExists=/dev/nvidia0) + `cpuinfo-gpu.service`(oneshot, RemainAfterExit) 추가. NVIDIA 드라이버가 패키지로 늦게 로드돼도 `/dev/nvidia0` 등장 시 cpuinfo.sh를 1회 재실행해 GPU 보강. 루프 방지(PathExists+RemainAfterExit), 비-nvidia/Intel·AMD 환경엔 inert(미발화).
- **universal.json**: cpuinfo.sh / install.sh sha256 갱신.

## 검증 (라이브 DSM 7.4.0-90075, SA6400 + Quadro P620)
- gpu_info: `{"name":"NVIDIA Quadro P620","status":"compatible","clock":"1354 MHz","memory":"2048 MiB","temperature_c":40,"tempwarn":false,...}`
- path 유닛: gpu_info 삭제 → path start → `/dev/nvidia0` 존재로 즉시 트리거 → 재생성 확인. `SubState=exited`, 시작시각 불변(루프 없음), enable로 영속화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)